### PR TITLE
Repository Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lhs"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "z3",
+ "z3-sys",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,15 +230,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "mir-analyzer"
-version = "0.1.0"
-dependencies = [
- "clap",
- "z3",
- "z3-sys",
-]
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mir-analyzer"
+name = "lhs"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -66,33 +66,25 @@ You can specify an action using the -a flag. We currently support three actions,
 3) `Local`: print local declarations (variables)
 4) `Query`: provides the result of whether or not there is a potential write to `/proc/self/mem`
 
-To get trace for a file named `example.rs` you can run:
-```bash
-cargo run -- -s example.rs -a trace
-```
 An example output for the results:
 ```bash
 ❯ cargo run -- -s examples/ex1.rs -a query
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
-     Running `target/debug/mir-analyzer -s examples/ex1.rs -a query`
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
+     Running `target/debug/lhs -s examples/ex1.rs -a query`
 MIR for function: DefId(0:5 ~ ex1[6c4e]::write_to_file)
 examples/ex1.rs:4:1: 7:2
 Unsupported Type: ()
 Unsupported Type: !
 Unsupported Type: ()
 Unsupported Type: ()
-bb0
-unknown statement...
-unknown statement...
-unknown statement...
-unknown statement...
-unknown statement...
-Found fs::write call
+START: Path 0!
+	bb0
+	Found fs::write call
 Model:
 2 -> "/proc/self/./mem"
 
 WARNING: potential write to `/proc/self/mem`
-        examples/ex1.rs:5:5: 5:14 (#0)
+	examples/ex1.rs:5:5: 5:14 (#0)
 ```
 
 ## Examples

--- a/inputoutput.md
+++ b/inputoutput.md
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::io::{self, ErrorKind};
 ```
 
-1. This function does contain an input (`filename: /proc/self/mem`) such that a safety property (write to /proc/self/mem) is violated.
+## 1. This function does contain an input (`filename: /proc/self/mem`) such that a safety property (write to /proc/self/mem) is violated.
 ```Rust
 pub fn write_to_file(contents: &str, filename: &str) -> io::Result<()> {
     fs::write(filename, contents)?;
@@ -23,7 +23,7 @@ WARNING: potential write to `/proc/self/mem`
         examples/ex1.rs:5:5: 5:14 (#0)
 ```
 
-2. This function also contains an input (filename: `/proc/../proc/self/mem`) such that a safety property (write to /proc/self/mem) is violated.
+## 2. This function also contains an input (filename: `/proc/../proc/self/mem`) such that a safety property (write to /proc/self/mem) is violated.
 ```Rust
 pub fn write_to_file_safe(contents: &str, filename: &str) -> io::Result<()> {
     if filename == "/proc/self/mem" {
@@ -39,7 +39,7 @@ WARNING: potential write to `/proc/self/mem`
         examples/ex2.rs:8:5: 8:14 (#0)
 ```
 
-3. This function contains no input such that a write to /proc/self/mem occurs.
+## 3. This function contains no input such that a write to /proc/self/mem occurs.
 ```Rust
 pub fn write_to_file_actually_safe(contents: &str, filename: &str) -> io::Result<()> {
     let filename_realpath: PathBuf = fs::canonicalize(filename)?;
@@ -56,7 +56,7 @@ pub fn write_to_file_actually_safe(contents: &str, filename: &str) -> io::Result
 No potential writes to `/proc/self/mem` detected!
 ```
 
-4. This function contains an input (operation: `|x| {fs::write("hello", "/proc/self/mem"); x}`)such that a write to /proc/self/mem occurs.
+## 4. This function contains an input (operation: `|x| {fs::write("hello", "/proc/self/mem"); x}`)such that a write to /proc/self/mem occurs.
 ```Rust
 pub fn apply_operation_twice(num: i32, operation: impl Fn(i32) -> i32) -> i32 {
     operation(operation(num))
@@ -69,7 +69,7 @@ No potential writes to `/proc/self/mem` detected!
 Note, this is intended behavior as LHS evaluates every single function located in the source file.
 It does not attempt to trace through function logic that is being called upon.
 
-5. This function contains no input such that a write to /proc/self/mem occurs.
+## 5. This function contains no input such that a write to /proc/self/mem occurs.
 ```Rust
 pub fn write_to_hw3(contents: &str)-> io::Result<()> {
     Ok(fs::write("~/UCDavis/PL/2024/summer/REU/LHS/main.rs", contents)?)
@@ -80,8 +80,8 @@ pub fn write_to_hw3(contents: &str)-> io::Result<()> {
 No potential writes to `/proc/self/mem` detected!
 ```
 
-6. The following two functions showcases the if/else branching traces.
-a) Write to `/proc/self/mem` occurs:
+## 6. The following two functions showcases the if/else branching traces.
+### a) Write to `/proc/self/mem` occurs:
 ```Rust
 fn main() {
     let x: isize = 1;
@@ -97,7 +97,7 @@ fn main() {
 WARNING: potential write to `/proc/self/mem`
         examples/ex6a.rs:4:9: 4:23 (#0)
 ```
-b) Write to `/proc/self/mem` does not occur:
+### b) Write to `/proc/self/mem` does not occur:
 ```Rust
 fn main() {
     let x: isize = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,22 @@
+#![feature(rustc_private)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+#![feature(mapped_lock_guards)]
+#![allow(dead_code)]
+
+extern crate rustc_driver;
+extern crate rustc_error_codes;
+extern crate rustc_errors;
+extern crate rustc_hash;
+extern crate rustc_hir;
+extern crate rustc_interface;
+extern crate rustc_session;
+extern crate rustc_span;
+
+extern crate rustc_data_structures;
+extern crate rustc_middle;
+extern crate rustc_abi;
+
+pub mod symexec;
+pub mod parser;
+pub mod operand;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,8 @@ use std::path::{Path, PathBuf};
 
 const DEF_ID_PATH_BUFF: usize = 5175;
 
-mod parser;
-pub mod symexec;
-use crate::parser::MIRParser;
+use lhs::symexec;
+use lhs::parser::MIRParser;
 
 // -------------------- START RUSTC PORTION --------------------
 extern crate rustc_driver;
@@ -52,7 +51,7 @@ fn main() {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "mir_analyzer")]
+#[command(name = "LHS: Leveraging (not) HIR via Symbolic execution")]
 #[command(version = "1.0.1")]
 #[command(about = "A command line utility for searching for analyzing a given Rust code's MIR and verifying proc/self/mem safety", long_about = None)]
 pub struct Args {

--- a/src/operand.rs
+++ b/src/operand.rs
@@ -1,0 +1,141 @@
+use rustc_middle::mir::interpret::{AllocRange, ConstAllocation};
+use rustc_middle::mir::{
+    BasicBlock, CallSource, Const, ConstValue, Local, Place,
+};
+use rustc_middle::ty::ScalarInt;
+use rustc_middle::ty::TyKind;
+
+use rustc_middle::mir::Operand;
+
+// Get the DefID associated with a given Operand (function)
+pub fn get_operand_def_id<'tcx>(operand: &Operand<'tcx>) -> Option<usize> {
+    match operand {
+        Operand::Copy(_place) => {
+            println!(
+                "get_operand_def_id: This should never happen, contact Hassnain if this is printed"
+            );
+            None
+        }
+        Operand::Move(place) => None,
+        Operand::Constant(place) => {
+            let constant = place.const_;
+            match constant {
+                Const::Ty(_ty, _const) => {
+                    println!("get_operand_def_id: This should never happen, contact Hassnain if this is printed");
+                    None
+                }
+                Const::Unevaluated(_unevaluated_const, _ty) => {
+                    println!("get_operand_def_id: This should never happen, contact Hassnain if this is printed");
+                    None
+                }
+                Const::Val(const_value, ty) => {
+                    if let TyKind::FnDef(def_id, idk) = ty.kind() {
+                        return Some(def_id.index.as_usize());
+                    }
+                    None
+                }
+            }
+        }
+    }
+}
+
+// Get the constant string from an Operand::Constant.const_ of type Const::Val
+pub fn get_operand_const_string<'tcx>(operand: &Operand<'tcx>) -> Option<String> {
+    match operand {
+        Operand::Copy(_place) => {
+            println!(
+                "get_operand_const_string: This should never happen, contact Hassnain if this is printed"
+            );
+            None
+        }
+        Operand::Move(place) => {
+            println!(
+                "get_operand_const_string: This should never happen, contact Hassnain if this is printed"
+            );
+            None
+        }
+        Operand::Constant(place) => {
+            let constant = place.const_;
+            match constant {
+                Const::Ty(_ty, _const) => {
+                    println!("get_operand_const_string: This should never happen, contact Hassnain if this is printed");
+                    None
+                }
+                Const::Unevaluated(_unevaluated_const, _ty) => {
+                    println!("get_operand_const_string: This should never happen, contact Hassnain if this is printed");
+                    None
+                }
+                Const::Val(const_value, ty) => {
+                    match const_value {
+                        ConstValue::Slice { data, meta } => {
+                            if let Some(str_data) = extract_string_from_const(&data, meta)
+                            {
+                                return Some(str_data);
+                            }
+                        }
+                        _ => {
+                            println!("get_operand_const_string: This should never happen, contact Hassnain if this is printed");
+                        }
+                    }
+                    None
+                }
+            }
+        }
+    }
+}
+
+pub fn get_operand_local<'tcx>(operand: &Operand<'tcx>) -> Option<usize> {
+    match operand {
+        Operand::Copy(_place) => {
+            println!(
+                "get_operand_local: This should never happen, contact Hassnain if this is printed"
+            );
+            None
+        }
+        Operand::Move(place) => {
+            let local = place.local;
+            let projection = place.projection;
+            Some(local.as_usize())
+        }
+        Operand::Constant(place) => {
+            Some(0)
+            // None
+        }
+    }
+}
+
+pub fn extract_string_from_const<'tcx>(
+    data: &'tcx ConstAllocation<'tcx>, //pub struct ConstAllocation<'tcx>(pub Interned<'tcx, Allocation>);
+    meta: u64,
+) -> Option<String> {
+    println!("\tData: {:?}", data);
+    println!("\tMeta: {:?}", meta);
+
+    //0: Interned<'tcx, Allocation>
+    let range: AllocRange = AllocRange {
+        start: rustc_abi::Size::from_bytes(0),
+        size: rustc_abi::Size::from_bytes(meta),
+    };
+    let allocation = &data.0.get_bytes_unchecked(range); //this is alignment
+
+    let a: String = String::from_utf8(allocation.to_vec()).unwrap();
+
+    return Some(a);
+}
+
+pub fn get_operand_span(operand: &Operand) -> Option<rustc_span::Span> {
+    match operand {
+        Operand::Copy(_place) => {
+            println!("get_operand_span: Unsupported, This function currently caters only for constants. ");
+            return None;
+        }
+        Operand::Move(place) => {
+            println!("get_operand_span: Unsupported, This function currently caters only for constants. ");
+            None
+        }
+        Operand::Constant(place) => {
+            let const_span = place.span;
+            return Some(const_span);
+        }
+    }
+}


### PR DESCRIPTION
Refactored code such that Hassnain's helper functions are now all moved into `operand.rs`, but I'm unsure if I might've inadvertently broke anything.